### PR TITLE
Using php-7.4 instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
 
 os:
   - linux
@@ -39,7 +39,6 @@ script: skip
 
 jobs:
   allow_failures:
-    - php: 7.4snapshot
     - php: nightly
     #- os: windows
   include:


### PR DESCRIPTION
# Changed log
- Using the `php-7.4` because it's available on Travis CI build.